### PR TITLE
fix type used in docs for NewEncoder in handler

### DIFF
--- a/handler/README.md
+++ b/handler/README.md
@@ -53,7 +53,7 @@ so now you can just worry about what PutJob does.
 pkg existence will be checked. The pkg needs to have funcs :
 
     func NewDecoder(r io.Reader) *Decoder
-    func NewEncoder(r io.Reader) *Encoder
+    func NewEncoder(w io.Writer) *Encoder
 
 and types
 

--- a/handler/generator.go
+++ b/handler/generator.go
@@ -45,7 +45,7 @@
 // pkg existence will be checked.
 // The pkg needs to have funcs :
 //  func NewDecoder(r io.Reader) *Decoder
-//  func NewEncoder(r io.Reader) *Encoder
+//  func NewEncoder(w io.Writer) *Encoder
 // and types
 //  type Encoder interface {
 //      Encode(v interface{}) error


### PR DESCRIPTION
... from `func NewEncoder(r io.Reader) *Encoder`
to `func NewEncoder(w io.Writer) *Encoder`